### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/_site/404.html
+++ b/_site/404.html
@@ -449,7 +449,7 @@
       </ul>
     </nav>
     <p class="disclaimer">
-        OWASP, Open Web Application Security Project, and Global AppSec are registered trademarks and AppSec Days, AppSec California, AppSec Cali, SnowFROC, LASCON, and the OWASP logo are trademarks of the OWASP Foundation, Inc. Unless otherwise specified, all content on the site is Creative Commons Attribution-ShareAlike v4.0 and provided without warranty of service or accuracy. For more information, please refer to our <a href="/www-policy/operational/general-disclaimer.html">General Disclaimer</a>. OWASP does not endorse or recommend commercial products or services, allowing our community to remain vendor neutral with the collective wisdom of the best minds in software security worldwide. Copyright 2021, OWASP Foundation, Inc.      
+        OWASP, Open Worldwide Application Security Project, and Global AppSec are registered trademarks and AppSec Days, AppSec California, AppSec Cali, SnowFROC, LASCON, and the OWASP logo are trademarks of the OWASP Foundation, Inc. Unless otherwise specified, all content on the site is Creative Commons Attribution-ShareAlike v4.0 and provided without warranty of service or accuracy. For more information, please refer to our <a href="/www-policy/operational/general-disclaimer.html">General Disclaimer</a>. OWASP does not endorse or recommend commercial products or services, allowing our community to remain vendor neutral with the collective wisdom of the best minds in software security worldwide. Copyright 2021, OWASP Foundation, Inc.      
     </p>
   </section>
 </footer>

--- a/_site/index.html
+++ b/_site/index.html
@@ -445,7 +445,7 @@
 </table>
 
 <h2 id="acerca-de-owasp">Acerca de OWASP</h2>
-<p>El Open Web Application Security Project (OWASP) es una fundación sin fines de lucro que trabaja para mejorar la seguridad del software. Nuestros proyectos incluyen:</p>
+<p>El Open Worldwide Application Security Project (OWASP) es una fundación sin fines de lucro que trabaja para mejorar la seguridad del software. Nuestros proyectos incluyen:</p>
 
 <ul>
   <li>Proyectos de software de código abierto liderados por la comunidad.</li>
@@ -705,7 +705,7 @@
       </ul>
     </nav>
     <p class="disclaimer">
-        OWASP, Open Web Application Security Project, and Global AppSec are registered trademarks and AppSec Days, AppSec California, AppSec Cali, SnowFROC, LASCON, and the OWASP logo are trademarks of the OWASP Foundation, Inc. Unless otherwise specified, all content on the site is Creative Commons Attribution-ShareAlike v4.0 and provided without warranty of service or accuracy. For more information, please refer to our <a href="/www-policy/operational/general-disclaimer.html">General Disclaimer</a>. OWASP does not endorse or recommend commercial products or services, allowing our community to remain vendor neutral with the collective wisdom of the best minds in software security worldwide. Copyright 2021, OWASP Foundation, Inc.      
+        OWASP, Open Worldwide Application Security Project, and Global AppSec are registered trademarks and AppSec Days, AppSec California, AppSec Cali, SnowFROC, LASCON, and the OWASP logo are trademarks of the OWASP Foundation, Inc. Unless otherwise specified, all content on the site is Creative Commons Attribution-ShareAlike v4.0 and provided without warranty of service or accuracy. For more information, please refer to our <a href="/www-policy/operational/general-disclaimer.html">General Disclaimer</a>. OWASP does not endorse or recommend commercial products or services, allowing our community to remain vendor neutral with the collective wisdom of the best minds in software security worldwide. Copyright 2021, OWASP Foundation, Inc.      
     </p>
   </section>
 </footer>

--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ Visita nuestra página de Meetup para registrarte en los próximos eventos: [Mee
 | ***Victor Vera*** | ***Roberto Teran*** |
 
 ## Acerca de OWASP
-El Open Web Application Security Project (OWASP) es una fundación sin fines de lucro que trabaja para mejorar la seguridad del software. Nuestros proyectos incluyen:
+El Open Worldwide Application Security Project (OWASP) es una fundación sin fines de lucro que trabaja para mejorar la seguridad del software. Nuestros proyectos incluyen:
 
 - Proyectos de software de código abierto liderados por la comunidad.
 - Más de 275 capítulos locales en todo el mundo.


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)
- BlueSky: [arkid15r.com](https://bsky.app/profile/arkid15r.com)